### PR TITLE
Feature: JPA 엔티티 및 DTO 작성, JPA Auditing 적용

### DIFF
--- a/src/main/java/com/goorm/devlink/authservice/AuthServiceApplication.java
+++ b/src/main/java/com/goorm/devlink/authservice/AuthServiceApplication.java
@@ -2,8 +2,10 @@ package com.goorm.devlink.authservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class AuthServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/goorm/devlink/authservice/dto/UserDto.java
+++ b/src/main/java/com/goorm/devlink/authservice/dto/UserDto.java
@@ -1,0 +1,33 @@
+package com.goorm.devlink.authservice.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+@Data
+@Builder
+@NotNull
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDto {
+
+    @NotNull
+    @Size(min = 3, max = 50)
+    private String email;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @NotNull
+    @Size(min = 3, max = 100)
+    private String password;
+
+    @NotNull
+    @Size(min = 3, max = 50)
+    private String nickname;
+
+    private String userUuid;
+}

--- a/src/main/java/com/goorm/devlink/authservice/entity/AuditingFields.java
+++ b/src/main/java/com/goorm/devlink/authservice/entity/AuditingFields.java
@@ -1,0 +1,32 @@
+package com.goorm.devlink.authservice.entity;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
+@ToString
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class AuditingFields {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt; // 생성일시
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt; // 수정일시
+}

--- a/src/main/java/com/goorm/devlink/authservice/entity/Authority.java
+++ b/src/main/java/com/goorm/devlink/authservice/entity/Authority.java
@@ -16,7 +16,7 @@ import javax.persistence.Table;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Authority {
+public class Authority extends AuditingFields {
 
     @Id
     @Column(name = "authority_name", length = 50)

--- a/src/main/java/com/goorm/devlink/authservice/entity/Authority.java
+++ b/src/main/java/com/goorm/devlink/authservice/entity/Authority.java
@@ -16,7 +16,7 @@ import javax.persistence.Table;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Authority extends AuditingFields {
+public class Authority {
 
     @Id
     @Column(name = "authority_name", length = 50)

--- a/src/main/java/com/goorm/devlink/authservice/entity/Authority.java
+++ b/src/main/java/com/goorm/devlink/authservice/entity/Authority.java
@@ -1,0 +1,24 @@
+package com.goorm.devlink.authservice.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "authority")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Authority {
+
+    @Id
+    @Column(name = "authority_name", length = 50)
+    private String authorityName;
+}

--- a/src/main/java/com/goorm/devlink/authservice/entity/User.java
+++ b/src/main/java/com/goorm/devlink/authservice/entity/User.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 import java.util.Set;
@@ -37,7 +38,11 @@ public class User extends AuditingFields {
     @Column(name = "activated")
     private boolean activated;
 
+    @Column(name = "user_uuid")
     private String userUuid;
+
+    @Column(name = "is_deleted", columnDefinition = "boolean default false")
+    private boolean isDeleted;
 
     @ManyToMany
     @JoinTable(

--- a/src/main/java/com/goorm/devlink/authservice/entity/User.java
+++ b/src/main/java/com/goorm/devlink/authservice/entity/User.java
@@ -15,7 +15,7 @@ import java.util.Set;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class User {
+public class User extends AuditingFields {
 
     @JsonIgnore
     @Id
@@ -45,5 +45,5 @@ public class User {
             joinColumns = {@JoinColumn(name = "user_id", referencedColumnName = "user_id")},
             inverseJoinColumns = {@JoinColumn(name = "authority_name", referencedColumnName = "authority_name")})
     private Set<Authority> authorities;
-    
+
 }

--- a/src/main/java/com/goorm/devlink/authservice/entity/User.java
+++ b/src/main/java/com/goorm/devlink/authservice/entity/User.java
@@ -1,0 +1,49 @@
+package com.goorm.devlink.authservice.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.Set;
+
+@Entity
+@Table(name = "users")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @JsonIgnore
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "email", length = 50, unique = true)
+    private String email;
+
+    @JsonIgnore
+    @Column(name = "password", length = 100)
+    private String password;
+
+    @Column(name = "nickname", length = 50)
+    private String nickname;
+
+    @JsonIgnore
+    @Column(name = "activated")
+    private boolean activated;
+
+    private String userUuid;
+
+    @ManyToMany
+    @JoinTable(
+            name = "user_authority",
+            joinColumns = {@JoinColumn(name = "user_id", referencedColumnName = "user_id")},
+            inverseJoinColumns = {@JoinColumn(name = "authority_name", referencedColumnName = "authority_name")})
+    private Set<Authority> authorities;
+    
+}


### PR DESCRIPTION
* 인증/인가에 필요한 도메인인 User와 Authority 엔티티를 설계한 ERD에 맞게 작성
* createAt과 modifiedAt 같은 컬럼들이 자동으로 등록되기 위해서 JPA Auditing 적용
* isDeleted 속성의 경우 기본적으로는 false 값을 유지하도록 함
* Entity가 로직에서 직접 사용되지 않도록 DTO 작성