### PR TITLE
Refactor: JWT 수정 - 로직 수정 및 Refresh Token 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/goorm/devlink/authservice/config/SecurityConfig.java
+++ b/src/main/java/com/goorm/devlink/authservice/config/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers("/auth-service/api/join").permitAll()
                 .antMatchers("/auth-service/api/login").permitAll()
+                .antMatchers("/auth-service/api/reissue").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .apply(new JwtSecurityConfig(tokenProvider));

--- a/src/main/java/com/goorm/devlink/authservice/config/SecurityConfig.java
+++ b/src/main/java/com/goorm/devlink/authservice/config/SecurityConfig.java
@@ -4,10 +4,8 @@ import com.goorm.devlink.authservice.jwt.JwtAccessDeniedHandler;
 import com.goorm.devlink.authservice.jwt.JwtAuthenticationEntryPoint;
 import com.goorm.devlink.authservice.jwt.JwtSecurityConfig;
 import com.goorm.devlink.authservice.jwt.TokenProvider;
-import com.goorm.devlink.authservice.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
@@ -25,7 +23,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final TokenProvider tokenProvider;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
-    private final UserRepository userRepository;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -56,9 +53,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers("/auth-service/api/join").permitAll()
                 .antMatchers("/auth-service/api/login").permitAll()
-                .antMatchers(HttpMethod.GET, "/auth-service/api/users/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
-                .apply(new JwtSecurityConfig(tokenProvider, userRepository));
+                .apply(new JwtSecurityConfig(tokenProvider));
     }
 }

--- a/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
+++ b/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
@@ -1,8 +1,8 @@
 package com.goorm.devlink.authservice.controller;
 
+import com.goorm.devlink.authservice.dto.TokenDto;
 import com.goorm.devlink.authservice.dto.UserDto;
-import com.goorm.devlink.authservice.jwt.JwtFilter;
-import com.goorm.devlink.authservice.jwt.TokenProvider;
+import com.goorm.devlink.authservice.service.AuthService;
 import com.goorm.devlink.authservice.service.UserService;
 import com.goorm.devlink.authservice.vo.request.UserJoinReqeust;
 import com.goorm.devlink.authservice.vo.request.UserLoginRequest;
@@ -12,10 +12,6 @@ import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
@@ -27,8 +23,7 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
-    private final TokenProvider tokenProvider;
-    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final AuthService authService;
 
     @PostMapping("/join")
     public ResponseEntity<Void> signUp(@RequestBody UserJoinReqeust reqeust) {
@@ -39,16 +34,11 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<Void> login(@RequestBody UserLoginRequest request) {
-        UsernamePasswordAuthenticationToken authenticationToken =
-                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword());
-
-        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        String jwt = tokenProvider.createToken(authentication);
+    public ResponseEntity<TokenDto> login(@RequestBody UserLoginRequest request) {
+        TokenDto tokenDto = authService.authorize(request.getEmail(), request.getPassword());
         HttpHeaders headers = new HttpHeaders();
-        headers.add(JwtFilter.AUTHORIZATION_HEADER, "Bearer " + jwt);
+        headers.add("accessToken", tokenDto.getAccessToken());
+        headers.add("refreshToken", tokenDto.getRefreshToken());
 
         return new ResponseEntity<>(headers, HttpStatus.OK);
     }

--- a/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
+++ b/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
@@ -36,6 +36,7 @@ public class UserController {
     @PostMapping("/login")
     public ResponseEntity<TokenDto> login(@RequestBody UserLoginRequest request) {
         TokenDto tokenDto = authService.authorize(request.getEmail(), request.getPassword());
+
         HttpHeaders headers = new HttpHeaders();
         headers.add("accessToken", tokenDto.getAccessToken());
         headers.add("refreshToken", tokenDto.getRefreshToken());
@@ -62,5 +63,19 @@ public class UserController {
         });
 
         return ResponseEntity.ok(userResponseList);
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenDto> reissue(
+            @RequestHeader("accessToken") String accessToken,
+            @RequestHeader("refreshToken") String refreshToken) {
+
+        TokenDto tokenDto = authService.reissue(accessToken, refreshToken);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("accessToken", tokenDto.getAccessToken());
+        headers.add("refreshToken", tokenDto.getRefreshToken());
+
+        return new ResponseEntity<>(headers, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/goorm/devlink/authservice/dto/TokenDto.java
+++ b/src/main/java/com/goorm/devlink/authservice/dto/TokenDto.java
@@ -1,0 +1,20 @@
+package com.goorm.devlink.authservice.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TokenDto {
+
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder
+    public TokenDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/goorm/devlink/authservice/exception/ErrorCode.java
+++ b/src/main/java/com/goorm/devlink/authservice/exception/ErrorCode.java
@@ -8,11 +8,12 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
 
-    DUPLICATED_USER_ACCOUNT_ID(HttpStatus.CONFLICT, "User Email is duplicated"),
+    DUPLICATED_USER_EMAIL(HttpStatus.CONFLICT, "User Email is duplicated"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "User not founded"),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "Password is invalid"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "Token is invalid"),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "Access Token is invalid"),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token is invalid"),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "Article not founded"),
     INVALID_PERMISSION(HttpStatus.UNAUTHORIZED, "Permission is invalid");
 

--- a/src/main/java/com/goorm/devlink/authservice/jwt/JwtFilter.java
+++ b/src/main/java/com/goorm/devlink/authservice/jwt/JwtFilter.java
@@ -1,7 +1,5 @@
 package com.goorm.devlink.authservice.jwt;
 
-import com.goorm.devlink.authservice.entity.User;
-import com.goorm.devlink.authservice.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -13,7 +11,6 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @Slf4j
@@ -22,11 +19,9 @@ public class JwtFilter extends GenericFilterBean {
     public static final String AUTHORIZATION_HEADER = "Authorization";
 
     private final TokenProvider tokenProvider;
-    private final UserRepository userRepository;
 
-    public JwtFilter(TokenProvider tokenProvider, UserRepository userRepository) {
+    public JwtFilter(TokenProvider tokenProvider) {
         this.tokenProvider = tokenProvider;
-        this.userRepository = userRepository;
     }
 
     // 토큰의 인증정보를 SecurityContext에 저장하는 역할을 수행
@@ -34,7 +29,6 @@ public class JwtFilter extends GenericFilterBean {
     public void doFilter(ServletRequest request, ServletResponse response,
                          FilterChain filterChain) throws IOException, ServletException {
         HttpServletRequest httpServletRequest = (HttpServletRequest) request;
-        HttpServletResponse httpServletResponse = (HttpServletResponse) response;
         String jwt = resolveToken(httpServletRequest);
         String requestURI = httpServletRequest.getRequestURI();
 
@@ -42,11 +36,6 @@ public class JwtFilter extends GenericFilterBean {
 
         if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
             Authentication authentication = tokenProvider.getAuthentication(jwt);
-
-            User user = userRepository.findOneWithAuthoritiesByEmail(authentication.getName()).get();
-            if(!user.getUserUuid().equals(httpServletRequest.getHeader("userUuid"))) {
-                httpServletResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED);
-            }
 
             SecurityContextHolder.getContext().setAuthentication(authentication);
             log.debug("Security Conext에 '{}' 인증 정보를 저장했습니다. {}", authentication.getName(), requestURI);

--- a/src/main/java/com/goorm/devlink/authservice/jwt/JwtSecurityConfig.java
+++ b/src/main/java/com/goorm/devlink/authservice/jwt/JwtSecurityConfig.java
@@ -1,6 +1,5 @@
 package com.goorm.devlink.authservice.jwt;
 
-import com.goorm.devlink.authservice.repository.UserRepository;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.DefaultSecurityFilterChain;
@@ -9,16 +8,14 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
 
     private final TokenProvider tokenProvider;
-    private final UserRepository userRepository;
 
-    public JwtSecurityConfig(TokenProvider tokenProvider, UserRepository userRepository) {
+    public JwtSecurityConfig(TokenProvider tokenProvider) {
         this.tokenProvider = tokenProvider;
-        this.userRepository = userRepository;
     }
 
     @Override
     public void configure(HttpSecurity http) throws Exception {
-        JwtFilter customFilter = new JwtFilter(tokenProvider, userRepository);
+        JwtFilter customFilter = new JwtFilter(tokenProvider);
         http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
     }
 }

--- a/src/main/java/com/goorm/devlink/authservice/redis/RedisConfig.java
+++ b/src/main/java/com/goorm/devlink/authservice/redis/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.goorm.devlink.authservice.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@EnableRedisRepositories
+@Configuration
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/goorm/devlink/authservice/redis/RedisProperties.java
+++ b/src/main/java/com/goorm/devlink/authservice/redis/RedisProperties.java
@@ -1,0 +1,24 @@
+package com.goorm.devlink.authservice.redis;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "spring.redis")
+@Component
+public class RedisProperties {
+
+    private int port;
+    private String host;
+
+    public int getPort() {
+        return this.port;
+    }
+
+    public String getHost() {
+        return this.host;
+    }
+}

--- a/src/main/java/com/goorm/devlink/authservice/redis/RedisUtil.java
+++ b/src/main/java/com/goorm/devlink/authservice/redis/RedisUtil.java
@@ -1,0 +1,50 @@
+package com.goorm.devlink.authservice.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Component
+public class RedisUtil {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, Object> redisBlackListTemplate;
+
+    public void set(String key, Object o, int minutes) {
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer(o.getClass()));
+        redisTemplate.opsForValue().set(key, o, minutes, TimeUnit.MINUTES);
+    }
+
+    public Object get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public boolean delete(String key) {
+        return Boolean.TRUE.equals(redisTemplate.delete(key));
+    }
+
+    public boolean hasKey(String key) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    public void setBlackList(String key, Object o, int minutes) {
+        redisBlackListTemplate.setValueSerializer(new Jackson2JsonRedisSerializer(o.getClass()));
+        redisBlackListTemplate.opsForValue().set(key, o, minutes, TimeUnit.MINUTES);
+    }
+
+    public Object getBlackList(String key) {
+        return redisBlackListTemplate.opsForValue().get(key);
+    }
+
+    public boolean deleteBlackList(String key) {
+        return Boolean.TRUE.equals(redisBlackListTemplate.delete(key));
+    }
+
+    public boolean hasKeyBlackList(String key) {
+        return Boolean.TRUE.equals(redisBlackListTemplate.hasKey(key));
+    }
+}

--- a/src/main/java/com/goorm/devlink/authservice/repository/UserRepository.java
+++ b/src/main/java/com/goorm/devlink/authservice/repository/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findOneWithAuthoritiesByEmail(String email);
 
     Optional<User> findByUserUuid(String userUuid);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/goorm/devlink/authservice/service/AuthService.java
+++ b/src/main/java/com/goorm/devlink/authservice/service/AuthService.java
@@ -5,4 +5,6 @@ import com.goorm.devlink.authservice.dto.TokenDto;
 public interface AuthService {
 
     TokenDto authorize(String email, String password);
+
+    TokenDto reissue(String accessToken, String refreshToken);
 }

--- a/src/main/java/com/goorm/devlink/authservice/service/AuthService.java
+++ b/src/main/java/com/goorm/devlink/authservice/service/AuthService.java
@@ -1,0 +1,8 @@
+package com.goorm.devlink.authservice.service;
+
+import com.goorm.devlink.authservice.dto.TokenDto;
+
+public interface AuthService {
+
+    TokenDto authorize(String email, String password);
+}

--- a/src/main/java/com/goorm/devlink/authservice/service/AuthServiceImpl.java
+++ b/src/main/java/com/goorm/devlink/authservice/service/AuthServiceImpl.java
@@ -1,6 +1,8 @@
 package com.goorm.devlink.authservice.service;
 
 import com.goorm.devlink.authservice.dto.TokenDto;
+import com.goorm.devlink.authservice.exception.AuthServiceException;
+import com.goorm.devlink.authservice.exception.ErrorCode;
 import com.goorm.devlink.authservice.jwt.TokenProvider;
 import com.goorm.devlink.authservice.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +34,19 @@ public class AuthServiceImpl implements AuthService {
                 .authenticate(authenticationToken);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
+        String authorities = getAuthorities(authentication);
+
+        return tokenProvider.createToken(authentication.getName(), authorities);
+    }
+
+    @Override
+    public TokenDto reissue(String accessToken, String refreshToken) {
+        if(!tokenProvider.validateToken(refreshToken)) {
+            throw new AuthServiceException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        Authentication authentication = tokenProvider.getAuthentication(accessToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
         String authorities = getAuthorities(authentication);
 
         return tokenProvider.createToken(authentication.getName(), authorities);

--- a/src/main/java/com/goorm/devlink/authservice/service/AuthServiceImpl.java
+++ b/src/main/java/com/goorm/devlink/authservice/service/AuthServiceImpl.java
@@ -1,0 +1,45 @@
+package com.goorm.devlink.authservice.service;
+
+import com.goorm.devlink.authservice.dto.TokenDto;
+import com.goorm.devlink.authservice.jwt.TokenProvider;
+import com.goorm.devlink.authservice.redis.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AuthServiceImpl implements AuthService {
+
+    private final TokenProvider tokenProvider;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final RedisUtil redisUtil;
+
+    @Override
+    public TokenDto authorize(String email, String password) {
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(email, password);
+
+        Authentication authentication = authenticationManagerBuilder.getObject()
+                .authenticate(authenticationToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        String authorities = getAuthorities(authentication);
+
+        return tokenProvider.createToken(authentication.getName(), authorities);
+    }
+
+    public String getAuthorities(Authentication authentication) {
+        return authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+    }
+}

--- a/src/main/java/com/goorm/devlink/authservice/service/UserServiceImpl.java
+++ b/src/main/java/com/goorm/devlink/authservice/service/UserServiceImpl.java
@@ -30,7 +30,7 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public void join(UserDto userDto) {
         if(userRepository.findOneWithAuthoritiesByEmail(userDto.getEmail()).orElse(null) != null) {
-            throw new RuntimeException("이미 가입되어 있는 유저입니다.");
+            throw new AuthServiceException(ErrorCode.DUPLICATED_USER_EMAIL);
         }
 
         Authority authority = Authority.builder()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,11 +20,15 @@ spring:
         show_sql: true
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect
     defer-datasource-initialization: true
+  redis:
+    port: 6379
+    host: 127.0.0.1
 
 jwt:
   header: Authorization
   secret: Z29vcm10aG9uLWRvY2tlci1wcm9qZWN0LWF1dGgtc2VydmljZS1qd3QtYXV0aG9yaXphdGlvbi1rZXktZ29vcm10aG9kLWRvY2tlci1wcm9qZWN0LWF1dGgtc2VydmljZQo=
-  token-validity-in-seconds: 86400
+  access-token-validity-in-seconds: 1800 # 초 단위
+  refresh-token-validity-in-seconds: 604800
 
 logging:
   level:


### PR DESCRIPTION
기존의 JWT의 Access Token만을 관리하는 것은 Access Token이 노출되게 된다면
큰 위험을 초래할 수 있기 때문에 Refresh Token을 도입하였음.
이를 관리하기 위한 Redis와 관련된 코드도 함께 작성.

* 로그인 기능 비즈니스 로직 수정 -> 기존의 Controller에서 동작하던 코드를 Service 단으로 이전하였음
* Token을 관리하기 위해서 블랙 리스트 전략을 사용하기 위한 Redis 유틸 및 설정 코드 작성
* Refresh 발급 코드 추가
* ErrorCode 수정 및 추가
* Access Token 재발행 기능 코드 작성
* 기존에 permitAll 이던 조회에 대해서 permitAll 제거