### PR TITLE
Feature: 유저 정보 수정 및 유저 탈퇴 로직 구현

### DIFF
--- a/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
+++ b/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
@@ -112,9 +112,12 @@ public class UserController {
 
     @DeleteMapping("/users")
     public ResponseEntity<Void> deleteUser(Authentication authentication,
-                                           @RequestHeader("userUuid") String userUuid) {
+                                           @RequestHeader("userUuid") String userUuid,
+                                           @RequestHeader("accessToken") String accessToken,
+                                           @RequestHeader("refreshToken") String refreshToken) {
 
         userService.deleteUser(authentication.getName(), userUuid);
+        authService.logout(accessToken, refreshToken);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
+++ b/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
@@ -6,12 +6,14 @@ import com.goorm.devlink.authservice.service.AuthService;
 import com.goorm.devlink.authservice.service.UserService;
 import com.goorm.devlink.authservice.vo.request.UserJoinReqeust;
 import com.goorm.devlink.authservice.vo.request.UserLoginRequest;
+import com.goorm.devlink.authservice.vo.request.UserModifyRequest;
 import com.goorm.devlink.authservice.vo.response.UserResponse;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
@@ -83,7 +85,18 @@ public class UserController {
     public ResponseEntity<Void> logout(
             @RequestHeader("accessToken") String accessToken,
             @RequestHeader("refreshToken") String refreshToken) {
+
         authService.logout(accessToken, refreshToken);
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PutMapping("/users")
+    public ResponseEntity<Void> modifyUserInfo(Authentication authentication,
+                                               @RequestHeader("userUuid") String userUuid,
+                                               @RequestBody UserModifyRequest request) {
+        userService.modifyUserinfo(authentication.getName(), userUuid, request.getNickname(), request.getPassword());
+
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
+++ b/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
@@ -41,7 +41,7 @@ public class UserController {
         TokenDto tokenDto = authService.authorize(request.getEmail(), request.getPassword());
 
         HttpHeaders headers = new HttpHeaders();
-        headers.add("accessToken", tokenDto.getAccessToken());
+        headers.add("Authorization", tokenDto.getAccessToken());
         headers.add("refreshToken", tokenDto.getRefreshToken());
 
         return new ResponseEntity<>(headers, HttpStatus.OK);
@@ -70,7 +70,7 @@ public class UserController {
 
     @PostMapping("/reissue")
     public ResponseEntity<TokenDto> reissue(
-            @RequestHeader("accessToken") String accessToken,
+            @RequestHeader("Authorization") String accessToken,
             @RequestHeader("refreshToken") String refreshToken) {
 
         TokenDto tokenDto = authService.reissue(accessToken, refreshToken);
@@ -84,7 +84,7 @@ public class UserController {
 
     @DeleteMapping("/logout")
     public ResponseEntity<Void> logout(
-            @RequestHeader("accessToken") String accessToken,
+            @RequestHeader("Authorization") String accessToken,
             @RequestHeader("refreshToken") String refreshToken) {
 
         authService.logout(accessToken, refreshToken);
@@ -113,7 +113,7 @@ public class UserController {
     @DeleteMapping("/users")
     public ResponseEntity<Void> deleteUser(Authentication authentication,
                                            @RequestHeader("userUuid") String userUuid,
-                                           @RequestHeader("accessToken") String accessToken,
+                                           @RequestHeader("Authorization") String accessToken,
                                            @RequestHeader("refreshToken") String refreshToken) {
 
         userService.deleteUser(authentication.getName(), userUuid);

--- a/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
+++ b/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
@@ -8,6 +8,7 @@ import com.goorm.devlink.authservice.vo.request.UserJoinReqeust;
 import com.goorm.devlink.authservice.vo.request.UserLoginRequest;
 import com.goorm.devlink.authservice.vo.request.UserModifyRequest;
 import com.goorm.devlink.authservice.vo.response.UserResponse;
+import com.goorm.devlink.authservice.vo.response.UserValidatedResponse;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpHeaders;
@@ -101,9 +102,9 @@ public class UserController {
     }
 
     @GetMapping("/validate")
-    public ResponseEntity<Boolean> validateCheck(Authentication authentication,
+    public ResponseEntity<UserValidatedResponse> validateCheck(Authentication authentication,
                                                  @RequestHeader("userUuid") String userUuid) {
         boolean isActivated = authService.validateCheck(authentication.getName(), userUuid);
-        return ResponseEntity.ok(isActivated);
+        return ResponseEntity.ok(new UserValidatedResponse(isActivated));
     }
 }

--- a/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
+++ b/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
@@ -99,4 +99,11 @@ public class UserController {
 
         return ResponseEntity.status(HttpStatus.OK).build();
     }
+
+    @GetMapping("/validate")
+    public ResponseEntity<Boolean> validateCheck(Authentication authentication,
+                                                 @RequestHeader("userUuid") String userUuid) {
+        boolean isActivated = authService.validateCheck(authentication.getName(), userUuid);
+        return ResponseEntity.ok(isActivated);
+    }
 }

--- a/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
+++ b/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
@@ -104,7 +104,18 @@ public class UserController {
     @GetMapping("/validate")
     public ResponseEntity<UserValidatedResponse> validateCheck(Authentication authentication,
                                                  @RequestHeader("userUuid") String userUuid) {
+
         boolean isActivated = authService.validateCheck(authentication.getName(), userUuid);
+
         return ResponseEntity.ok(new UserValidatedResponse(isActivated));
+    }
+
+    @DeleteMapping("/users")
+    public ResponseEntity<Void> deleteUser(Authentication authentication,
+                                           @RequestHeader("userUuid") String userUuid) {
+
+        userService.deleteUser(authentication.getName(), userUuid);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/goorm/devlink/authservice/entity/User.java
+++ b/src/main/java/com/goorm/devlink/authservice/entity/User.java
@@ -59,4 +59,8 @@ public class User extends AuditingFields {
             this.password = password;
         }
     }
+
+    public void changeDeleted(boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
 }

--- a/src/main/java/com/goorm/devlink/authservice/entity/User.java
+++ b/src/main/java/com/goorm/devlink/authservice/entity/User.java
@@ -50,4 +50,13 @@ public class User extends AuditingFields {
             inverseJoinColumns = {@JoinColumn(name = "authority_name", referencedColumnName = "authority_name")})
     private Set<Authority> authorities;
 
+    public void modifyUserInfo(String nickname, String password) {
+        if(nickname != null) {
+            this.nickname = nickname;
+        }
+
+        if(password != null) {
+            this.password = password;
+        }
+    }
 }

--- a/src/main/java/com/goorm/devlink/authservice/entity/User.java
+++ b/src/main/java/com/goorm/devlink/authservice/entity/User.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.util.Set;
@@ -15,6 +16,7 @@ import java.util.Set;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Where(clause = "is_deleted=false")
 public class User extends AuditingFields {
 
     @JsonIgnore
@@ -34,13 +36,13 @@ public class User extends AuditingFields {
     private String nickname;
 
     @JsonIgnore
-    @Column(name = "activated")
+    @Column(name = "activated", columnDefinition = "boolean default true NOT NULL")
     private boolean activated;
 
     @Column(name = "user_uuid")
     private String userUuid;
 
-    @Column(name = "is_deleted", columnDefinition = "boolean default false")
+    @Column(name = "is_deleted", columnDefinition = "boolean default false NOT NULL")
     private boolean isDeleted;
 
     @ManyToMany

--- a/src/main/java/com/goorm/devlink/authservice/exception/ErrorCode.java
+++ b/src/main/java/com/goorm/devlink/authservice/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
 
     DUPLICATED_USER_EMAIL(HttpStatus.CONFLICT, "User Email is duplicated"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "User not founded"),
+    INVALID_USER_UUID(HttpStatus.UNAUTHORIZED, "User UUID is invalid"),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "Password is invalid"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "Access Token is invalid"),

--- a/src/main/java/com/goorm/devlink/authservice/service/AuthService.java
+++ b/src/main/java/com/goorm/devlink/authservice/service/AuthService.java
@@ -9,4 +9,6 @@ public interface AuthService {
     TokenDto reissue(String accessToken, String refreshToken);
 
     void logout(String accessToken, String refreshToken);
+
+    boolean validateCheck(String email, String userUuid);
 }

--- a/src/main/java/com/goorm/devlink/authservice/service/AuthServiceImpl.java
+++ b/src/main/java/com/goorm/devlink/authservice/service/AuthServiceImpl.java
@@ -70,7 +70,6 @@ public class AuthServiceImpl implements AuthService {
             throw new AuthServiceException(ErrorCode.INVALID_USER_UUID);
         }
 
-        if (user.isDeleted()) return false;
         return user.isActivated();
     }
 

--- a/src/main/java/com/goorm/devlink/authservice/service/AuthServiceImpl.java
+++ b/src/main/java/com/goorm/devlink/authservice/service/AuthServiceImpl.java
@@ -1,10 +1,12 @@
 package com.goorm.devlink.authservice.service;
 
 import com.goorm.devlink.authservice.dto.TokenDto;
+import com.goorm.devlink.authservice.entity.User;
 import com.goorm.devlink.authservice.exception.AuthServiceException;
 import com.goorm.devlink.authservice.exception.ErrorCode;
 import com.goorm.devlink.authservice.jwt.TokenProvider;
 import com.goorm.devlink.authservice.redis.RedisUtil;
+import com.goorm.devlink.authservice.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -24,6 +26,7 @@ public class AuthServiceImpl implements AuthService {
     private final TokenProvider tokenProvider;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final RedisUtil redisUtil;
+    private final UserRepository userRepository;
 
     @Override
     public TokenDto authorize(String email, String password) {
@@ -41,7 +44,7 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public TokenDto reissue(String accessToken, String refreshToken) {
-        if(!tokenProvider.validateToken(refreshToken)) {
+        if (!tokenProvider.validateToken(refreshToken)) {
             throw new AuthServiceException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
@@ -56,6 +59,19 @@ public class AuthServiceImpl implements AuthService {
     public void logout(String accessToken, String refreshToken) {
         redisUtil.setBlackList(accessToken, "accessToken", 1800);
         redisUtil.setBlackList(refreshToken, "refreshToken", 60400);
+    }
+
+    @Override
+    public boolean validateCheck(String email, String userUuid) {
+        User user = userRepository.findByEmail(email).orElseThrow(() ->
+                new AuthServiceException(ErrorCode.USER_NOT_FOUND));
+
+        if (!user.getUserUuid().equals(userUuid)) {
+            throw new AuthServiceException(ErrorCode.INVALID_USER_UUID);
+        }
+
+        if (user.isDeleted()) return false;
+        return user.isActivated();
     }
 
     // 권한을 가져오는 메소드

--- a/src/main/java/com/goorm/devlink/authservice/service/UserService.java
+++ b/src/main/java/com/goorm/devlink/authservice/service/UserService.java
@@ -11,4 +11,6 @@ public interface UserService {
     UserDto getUserByUserUuid(String userUuid);
 
     List<UserDto> getUsers();
+
+    void modifyUserinfo(String email, String userUuid, String nickname, String password);
 }

--- a/src/main/java/com/goorm/devlink/authservice/service/UserService.java
+++ b/src/main/java/com/goorm/devlink/authservice/service/UserService.java
@@ -13,4 +13,6 @@ public interface UserService {
     List<UserDto> getUsers();
 
     void modifyUserinfo(String email, String userUuid, String nickname, String password);
+
+    void deleteUser(String email, String userUuid);
 }

--- a/src/main/java/com/goorm/devlink/authservice/service/UserServiceImpl.java
+++ b/src/main/java/com/goorm/devlink/authservice/service/UserServiceImpl.java
@@ -88,4 +88,16 @@ public class UserServiceImpl implements UserService {
 
         userRepository.save(user);
     }
+
+    @Override
+    public void deleteUser(String email, String userUuid) {
+        User user = userRepository.findByEmail(email).orElseThrow(() ->
+                new AuthServiceException(ErrorCode.USER_NOT_FOUND));
+
+        if(!user.getUserUuid().equals(userUuid)) {
+            throw new AuthServiceException(ErrorCode.INVALID_USER_UUID);
+        }
+
+        user.changeDeleted(true);
+    }
 }

--- a/src/main/java/com/goorm/devlink/authservice/service/UserServiceImpl.java
+++ b/src/main/java/com/goorm/devlink/authservice/service/UserServiceImpl.java
@@ -54,7 +54,7 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findByUserUuid(userUuid).orElseThrow(() ->
             new AuthServiceException(ErrorCode.USER_NOT_FOUND));
 
-        if(!user.isActivated() || user.isDeleted()) {
+        if(!user.isActivated()) {
             throw new AuthServiceException(ErrorCode.USER_NOT_FOUND);
         }
 
@@ -99,5 +99,6 @@ public class UserServiceImpl implements UserService {
         }
 
         user.changeDeleted(true);
+        userRepository.save(user);
     }
 }

--- a/src/main/java/com/goorm/devlink/authservice/service/UserServiceImpl.java
+++ b/src/main/java/com/goorm/devlink/authservice/service/UserServiceImpl.java
@@ -74,4 +74,18 @@ public class UserServiceImpl implements UserService {
 
         return userDtoList;
     }
+
+    @Override
+    public void modifyUserinfo(String email, String userUuid, String nickname, String password) {
+        User user = userRepository.findByEmail(email).orElseThrow(() ->
+                new AuthServiceException(ErrorCode.USER_NOT_FOUND));
+
+        if(!user.getUserUuid().equals(userUuid)) {
+            throw new AuthServiceException(ErrorCode.INVALID_USER_UUID);
+        }
+
+        user.modifyUserInfo(nickname, passwordEncoder.encode(password));
+
+        userRepository.save(user);
+    }
 }

--- a/src/main/java/com/goorm/devlink/authservice/vo/request/UserModifyRequest.java
+++ b/src/main/java/com/goorm/devlink/authservice/vo/request/UserModifyRequest.java
@@ -1,0 +1,14 @@
+package com.goorm.devlink.authservice.vo.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserModifyRequest {
+
+    private String nickname;
+    private String password;
+}

--- a/src/main/java/com/goorm/devlink/authservice/vo/response/UserValidatedResponse.java
+++ b/src/main/java/com/goorm/devlink/authservice/vo/response/UserValidatedResponse.java
@@ -1,0 +1,12 @@
+package com.goorm.devlink.authservice.vo.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserValidatedResponse {
+    private boolean isActivated;
+}


### PR DESCRIPTION
유저 정보 수정 및 회원 탈퇴 기능의 경우 많은 코드가 발생할 것 같지 않아 하나의 브랜치에서 작업하였음

- 유저 정보 수정 기능 작성
- 유저 탈퇴 기능 작성
- 유저 탈퇴 시에 기존의 JWT 토큰을 블랙리스트에 추가하는 로직 추가
- 유저 Validate Check 로직 작성
- 유저 조회 시에 is_deleted가 true인 유저는 필터되서 리턴하도록 어노테이션 적용