### PR TITLE
Feature: GitHub Login을 OAuth2를 사용하여 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ dependencies {
     implementation 'mysql:mysql-connector-java'
 //    runtimeOnly 'com.h2database:h2'
 
+    // github login
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation group: 'org.kohsuke', name: 'github-api', version: '1.125'
+
     implementation 'org.modelmapper:modelmapper:2.3.8'
 
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/main/java/com/goorm/devlink/authservice/AuthServiceApplication.java
+++ b/src/main/java/com/goorm/devlink/authservice/AuthServiceApplication.java
@@ -3,7 +3,10 @@ package com.goorm.devlink.authservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @EnableDiscoveryClient
 @EnableJpaAuditing
@@ -14,4 +17,8 @@ public class AuthServiceApplication {
         SpringApplication.run(AuthServiceApplication.class, args);
     }
 
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 }

--- a/src/main/java/com/goorm/devlink/authservice/config/SecurityConfig.java
+++ b/src/main/java/com/goorm/devlink/authservice/config/SecurityConfig.java
@@ -4,6 +4,8 @@ import com.goorm.devlink.authservice.jwt.JwtAccessDeniedHandler;
 import com.goorm.devlink.authservice.jwt.JwtAuthenticationEntryPoint;
 import com.goorm.devlink.authservice.jwt.JwtSecurityConfig;
 import com.goorm.devlink.authservice.jwt.TokenProvider;
+import com.goorm.devlink.authservice.service.CustomOAuth2UserService;
+import com.goorm.devlink.authservice.util.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -23,6 +25,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final TokenProvider tokenProvider;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler successHandler;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -55,8 +60,21 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/api/login").permitAll()
                 .antMatchers("/api/logout").permitAll()
                 .antMatchers("/api/reissue").permitAll()
+                .antMatchers("/login/**").permitAll()
+                .antMatchers("/home/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
-                .apply(new JwtSecurityConfig(tokenProvider));
+                .apply(new JwtSecurityConfig(tokenProvider))
+                .and()
+                .oauth2Login()
+                .authorizationEndpoint()
+                .baseUri("/login")
+                .and()
+                .redirectionEndpoint()
+                .baseUri("/login/oauth2/code/github")
+                .and()
+                .successHandler(successHandler)
+                .userInfoEndpoint()
+                .userService(customOAuth2UserService);
     }
 }

--- a/src/main/java/com/goorm/devlink/authservice/config/SecurityConfig.java
+++ b/src/main/java/com/goorm/devlink/authservice/config/SecurityConfig.java
@@ -7,15 +7,12 @@ import com.goorm.devlink.authservice.jwt.TokenProvider;
 import com.goorm.devlink.authservice.service.CustomOAuth2UserService;
 import com.goorm.devlink.authservice.util.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
@@ -28,11 +25,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2SuccessHandler successHandler;
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
 
     @Override
     public void configure(WebSecurity web) throws Exception {

--- a/src/main/java/com/goorm/devlink/authservice/controller/GitHubController.java
+++ b/src/main/java/com/goorm/devlink/authservice/controller/GitHubController.java
@@ -1,0 +1,19 @@
+package com.goorm.devlink.authservice.controller;
+
+import com.goorm.devlink.authservice.dto.TokenDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+public class GitHubController {
+
+    @GetMapping("/home")
+    public ResponseEntity home(@RequestParam String accessToken, @RequestParam String refreshToken) {
+        TokenDto token = new TokenDto(accessToken, refreshToken);
+        return ResponseEntity.ok(token);
+    }
+}

--- a/src/main/java/com/goorm/devlink/authservice/dto/OAuth2Attribute.java
+++ b/src/main/java/com/goorm/devlink/authservice/dto/OAuth2Attribute.java
@@ -1,0 +1,55 @@
+package com.goorm.devlink.authservice.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ToString
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class OAuth2Attribute {
+
+    private Map<String, Object> attributes;
+    private String attributeKey;
+    private String email;
+    private String nickname;
+
+    private Long id;
+
+    public static OAuth2Attribute of(String provider, String attributeKey,
+                                     Map<String, Object> attributes) {
+        switch (provider) {
+            case "github":
+                return ofGithub("id", attributes);
+            default:
+                throw new RuntimeException();
+        }
+    }
+
+    private static OAuth2Attribute ofGithub(String attributeKey,
+                                            Map<String, Object> attributes) {
+
+        Integer id = (Integer) attributes.get("id");
+        return OAuth2Attribute.builder()
+                .id(Long.valueOf(id))
+                .nickname((String) attributes.get("login"))
+                .email((String) attributes.get("email"))
+                .attributes(attributes)
+                .attributeKey(attributeKey)
+                .build();
+    }
+
+    public Map<String, Object> convertToMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("id", attributeKey);
+        map.put("key", attributeKey);
+        map.put("nickname", nickname);
+        map.put("email", email);
+        map.put("id", id);
+        return map;
+    }
+}

--- a/src/main/java/com/goorm/devlink/authservice/dto/OauthUserDto.java
+++ b/src/main/java/com/goorm/devlink/authservice/dto/OauthUserDto.java
@@ -1,0 +1,17 @@
+package com.goorm.devlink.authservice.dto;
+
+import com.goorm.devlink.authservice.entity.constant.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OauthUserDto {
+    private Long id;
+    private String email;
+    private String nickname;
+    private String userUuid;
+    private UserRole userRole;
+}

--- a/src/main/java/com/goorm/devlink/authservice/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/goorm/devlink/authservice/service/CustomOAuth2UserService.java
@@ -1,0 +1,47 @@
+package com.goorm.devlink.authservice.service;
+
+import com.goorm.devlink.authservice.dto.OAuth2Attribute;
+import com.goorm.devlink.authservice.entity.constant.UserRole;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService = new DefaultOAuth2UserService();
+
+        OAuth2User oAuth2User = oAuth2UserService.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        log.info("registrationId = {}", registrationId);
+        log.info("userNameAttributeName = {}", userNameAttributeName);
+        log.info(String.valueOf(oAuth2User));
+
+        OAuth2Attribute oAuth2Attribute =
+                OAuth2Attribute.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+
+        Map<String, Object> userAttribute = oAuth2Attribute.convertToMap();
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(UserRole.USER.name())),
+                userAttribute, "id");
+    }
+}

--- a/src/main/java/com/goorm/devlink/authservice/util/OAuth2SuccessHandler.java
+++ b/src/main/java/com/goorm/devlink/authservice/util/OAuth2SuccessHandler.java
@@ -1,0 +1,71 @@
+package com.goorm.devlink.authservice.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goorm.devlink.authservice.dto.TokenDto;
+import com.goorm.devlink.authservice.entity.User;
+import com.goorm.devlink.authservice.entity.constant.UserRole;
+import com.goorm.devlink.authservice.jwt.TokenProvider;
+import com.goorm.devlink.authservice.repository.UserRepository;
+import com.goorm.devlink.authservice.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final TokenProvider tokenProvider;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+    private final AuthService authService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
+
+        log.info("Principal에서 꺼낸 OAuth2User = {}", oAuth2User);
+
+        User user = new User();
+        user.setEmail(oAuth2User.getAttribute("email"));
+        user.setNickname(oAuth2User.getAttribute("nickname"));
+        user.setRole(UserRole.USER);
+        user.setUserUuid(UUID.randomUUID().toString());
+        user.setPassword("");
+
+        userRepository.save(user);
+
+        log.info("토큰 발행 시작");
+
+        String authorities = getAuthorities(authentication);
+        TokenDto token = tokenProvider.createToken(oAuth2User.getAttribute("email"), authorities);
+
+        log.info("token = {}", token);
+        // TODO: Front와 작업 및 합의 해서 리다이랙션 URI 수정
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString("/home")
+                .queryParam("accessToken", token.getAccessToken())
+                .queryParam("refreshToken", token.getRefreshToken());
+        String redirectUrl = uriBuilder.toUriString();
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+    }
+
+    // 권한을 가져오는 메소드
+    public String getAuthorities(Authentication authentication) {
+        return authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,11 +34,11 @@ spring:
     port: 6379
     host: 127.0.0.1
 
-jwt:
-  header: Authorization
-  secret: Z29vcm10aG9uLWRvY2tlci1wcm9qZWN0LWF1dGgtc2VydmljZS1qd3QtYXV0aG9yaXphdGlvbi1rZXktZ29vcm10aG9kLWRvY2tlci1wcm9qZWN0LWF1dGgtc2VydmljZQo=
-  access-token-validity-in-seconds: 1800 # 초 단위
-  refresh-token-validity-in-seconds: 604800
+#jwt:
+#  header: Authorization
+#  secret: Z29vcm10aG9uLWRvY2tlci1wcm9qZWN0LWF1dGgtc2VydmljZS1qd3QtYXV0aG9yaXphdGlvbi1rZXktZ29vcm10aG9kLWRvY2tlci1wcm9qZWN0LWF1dGgtc2VydmljZQo=
+#  access-token-validity-in-seconds: 1800 # 초 단위
+#  refresh-token-validity-in-seconds: 604800
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,14 @@
 server:
-  port: 0
+  port: 8080
 
 spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            client-id: e67ba6052e23676fbc3d
+            client-secret: d2a204d51d9c7d024eaabd16a29542177ed85922
   application:
     name: auth-service
   config:
@@ -27,11 +34,11 @@ spring:
     port: 6379
     host: 127.0.0.1
 
-#jwt:
-#  header: Authorization
-#  secret: Z29vcm10aG9uLWRvY2tlci1wcm9qZWN0LWF1dGgtc2VydmljZS1qd3QtYXV0aG9yaXphdGlvbi1rZXktZ29vcm10aG9kLWRvY2tlci1wcm9qZWN0LWF1dGgtc2VydmljZQo=
-#  access-token-validity-in-seconds: 1800 # 초 단위
-#  refresh-token-validity-in-seconds: 604800
+jwt:
+  header: Authorization
+  secret: Z29vcm10aG9uLWRvY2tlci1wcm9qZWN0LWF1dGgtc2VydmljZS1qd3QtYXV0aG9yaXphdGlvbi1rZXktZ29vcm10aG9kLWRvY2tlci1wcm9qZWN0LWF1dGgtc2VydmljZQo=
+  access-token-validity-in-seconds: 1800 # 초 단위
+  refresh-token-validity-in-seconds: 604800
 
 logging:
   level:


### PR DESCRIPTION
GitHub Login을 OAuth2를 사용하여 구현하였다.

이를 위해서 OAuth2 로그인 시에 기존 회원가입 로직을 수행하도록 하였으며,
JWT Token을 함께 발행할 수 있도록 구현하였다.

우리 프로젝트에서는 email를 사용해 사용자를 구별하지만,  
GitHub에서는 email 공개에 대한 기본값이 private이기 때문에 GitHub에서 public으로
전환해야지만 로그인이 가능하다.

또한, 홈페이지를 통한 회원가입과 깃허브 로그인을 통한 회원가입 시에도 이메일 중복에 대한 핸들링을 하였다.

ref
* [[Spring] Github OAuth 2.0 + Jwt를 통해 로그인하기](https://sleeg.tistory.com/entry/Spring-Github-OAuth-20-Jwt%EB%A5%BC-%ED%86%B5%ED%95%B4-%EB%A1%9C%EA%B7%B8%EC%9D%B8%ED%95%98%EA%B8%B0)
* [깃허브 OAuth2.0을 이용하여 로그인 구현하기](https://velog.io/@freemoon99/%EA%B9%83%ED%97%88%EB%B8%8C-OAuth2.0%EC%9D%84-%EC%9D%B4%EC%9A%A9%ED%95%98%EC%97%AC-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0-spring-boot-OAuth-jpa)
* [[Spring Boot] Spring OAuth 없이 Spring Boot로 Github OAuth 사용하기](https://somuchthings.tistory.com/131)
* [passport-github scope email이 없을 경우](https://velog.io/@suyeonpi/Dimelo-Project-github-email%EC%9D%B4-%EC%97%86%EC%9D%84-%EA%B2%BD%EC%9A%B0)