### PR TITLE
Refator: GitHub 소셜로그인과 홈페이지 회원가입 로직 분리

### DIFF
--- a/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
+++ b/src/main/java/com/goorm/devlink/authservice/controller/UserController.java
@@ -2,7 +2,6 @@ package com.goorm.devlink.authservice.controller;
 
 import com.goorm.devlink.authservice.dto.TokenDto;
 import com.goorm.devlink.authservice.dto.UserDto;
-import com.goorm.devlink.authservice.entity.constant.JoinType;
 import com.goorm.devlink.authservice.service.AuthService;
 import com.goorm.devlink.authservice.service.UserService;
 import com.goorm.devlink.authservice.vo.request.UserJoinReqeust;
@@ -33,7 +32,7 @@ public class UserController {
     @PostMapping("/join")
     public ResponseEntity<Void> signUp(@RequestBody UserJoinReqeust reqeust) {
         UserDto userDto = new ModelMapper().map(reqeust, UserDto.class);
-        userService.join(userDto, JoinType.HOMEPAGE);
+        userService.join(userDto);
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
@@ -58,7 +57,6 @@ public class UserController {
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(response);
-//        return new ResponseEntity<>(headers, HttpStatus.OK);
     }
 
     @GetMapping("/users/{userUuid}")

--- a/src/main/java/com/goorm/devlink/authservice/dto/OAuth2Attribute.java
+++ b/src/main/java/com/goorm/devlink/authservice/dto/OAuth2Attribute.java
@@ -17,6 +17,7 @@ public class OAuth2Attribute {
     private String attributeKey;
     private String email;
     private String nickname;
+    private String githubUrl;
 
     private Long id;
 
@@ -38,6 +39,7 @@ public class OAuth2Attribute {
                 .id(Long.valueOf(id))
                 .nickname((String) attributes.get("login"))
                 .email((String) attributes.get("email"))
+                .githubUrl((String) attributes.get("html_url"))
                 .attributes(attributes)
                 .attributeKey(attributeKey)
                 .build();
@@ -49,6 +51,7 @@ public class OAuth2Attribute {
         map.put("key", attributeKey);
         map.put("nickname", nickname);
         map.put("email", email);
+        map.put("url", githubUrl);
         map.put("id", id);
         return map;
     }

--- a/src/main/java/com/goorm/devlink/authservice/entity/constant/JoinType.java
+++ b/src/main/java/com/goorm/devlink/authservice/entity/constant/JoinType.java
@@ -1,5 +1,0 @@
-package com.goorm.devlink.authservice.entity.constant;
-
-public enum JoinType {
-    HOMEPAGE, GITHUB
-}

--- a/src/main/java/com/goorm/devlink/authservice/service/UserService.java
+++ b/src/main/java/com/goorm/devlink/authservice/service/UserService.java
@@ -1,13 +1,14 @@
 package com.goorm.devlink.authservice.service;
 
 import com.goorm.devlink.authservice.dto.UserDto;
-import com.goorm.devlink.authservice.entity.constant.JoinType;
 
 import java.util.List;
 
 public interface UserService {
 
-    void join(UserDto userDto, JoinType joinType);
+    void join(UserDto userDto);
+
+    void joinForGitHub(UserDto userDto, String githubUrl);
 
     UserDto getUserByUserUuid(String userUuid);
 

--- a/src/main/java/com/goorm/devlink/authservice/util/OAuth2SuccessHandler.java
+++ b/src/main/java/com/goorm/devlink/authservice/util/OAuth2SuccessHandler.java
@@ -2,7 +2,6 @@ package com.goorm.devlink.authservice.util;
 
 import com.goorm.devlink.authservice.dto.TokenDto;
 import com.goorm.devlink.authservice.dto.UserDto;
-import com.goorm.devlink.authservice.entity.constant.JoinType;
 import com.goorm.devlink.authservice.jwt.TokenProvider;
 import com.goorm.devlink.authservice.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -41,7 +40,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 .build();
 
         // 회원가입 로직
-        userService.join(userDto, JoinType.GITHUB);
+        userService.joinForGitHub(userDto, oAuth2User.getAttribute("url"));
 
         // JWT 토큰 발행 로직
         log.info("토큰 발행 시작");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8080
+  port: 0
 
 spring:
 #  security:


### PR DESCRIPTION
GitHub 소셜로그인과 홈페이지 회원가입 로직을 분리하였다.
그리고 회원가입 시에 프로필 생성을 위한 서비스간 통신에서 기존에는 GitHub Email을 보내도록 되어있었는데
이메일이 아닌 GitHub Profile URL을 보내도록 수정하였다.